### PR TITLE
Adding lifecycle events to kafkaListener and message filters

### DIFF
--- a/src/main/java/smartthings/konsumer/circuitbreaker/CircuitBreaker.java
+++ b/src/main/java/smartthings/konsumer/circuitbreaker/CircuitBreaker.java
@@ -1,8 +1,10 @@
 package smartthings.konsumer.circuitbreaker;
 
-import smartthings.konsumer.event.KonsumerEventListener;
+import smartthings.konsumer.KafkaListener;
 
 public interface CircuitBreaker {
+
+	void init(CircuitBreakerListener listener);
 
 	void blockIfOpen();
 
@@ -12,6 +14,6 @@ public interface CircuitBreaker {
 
 	void conditionalClose(String sourceId);
 
-	void addListener(KonsumerEventListener listener);
+	void destroy();
 
 }

--- a/src/main/java/smartthings/konsumer/circuitbreaker/CircuitBreakerListener.java
+++ b/src/main/java/smartthings/konsumer/circuitbreaker/CircuitBreakerListener.java
@@ -1,0 +1,9 @@
+package smartthings.konsumer.circuitbreaker;
+
+public interface CircuitBreakerListener {
+
+	void opened();
+
+	void closed();
+
+}

--- a/src/main/java/smartthings/konsumer/circuitbreaker/SimpleCircuitBreaker.java
+++ b/src/main/java/smartthings/konsumer/circuitbreaker/SimpleCircuitBreaker.java
@@ -2,42 +2,34 @@ package smartthings.konsumer.circuitbreaker;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import smartthings.konsumer.event.KonsumerEvent;
-import smartthings.konsumer.event.KonsumerEventListener;
-import smartthings.konsumer.util.ThreadFactoryBuilder;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.*;
-import java.util.concurrent.*;
 
 @ThreadSafe
 public class SimpleCircuitBreaker implements CircuitBreaker {
-
 	private final static Logger log = LoggerFactory.getLogger(SimpleCircuitBreaker.class);
 
 	private final Object mutex = new Object();
 
 	@GuardedBy("mutex")
 	private boolean open = false;
-
 	@GuardedBy("mutex")
 	private final Set<String> sources = new HashSet<>();
 
-	private final List<KonsumerEventListener> listeners = new CopyOnWriteArrayList<>();
+	private CircuitBreakerListener listener;
 
-	private final ExecutorService callbackExecutor;
-
-	public SimpleCircuitBreaker() {
-		this(Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
-			.setDaemon(true)
-			.setNameFormat("KafkaCircuitBreaker-callback")
-			.build())
-		);
+	@Override
+	public void init(CircuitBreakerListener listener) {
+		synchronized (mutex) {
+			this.listener = listener;
+		}
 	}
 
-	public SimpleCircuitBreaker(ExecutorService callbackExecutor) {
-		this.callbackExecutor = callbackExecutor;
+	@Override
+	public void destroy() {
+		//do nothing
 	}
 
 	@Override
@@ -68,7 +60,7 @@ public class SimpleCircuitBreaker implements CircuitBreaker {
 			if (sources.isEmpty()) {
 				log.info("CircuitBreaker opened by {}", sourceId);
 				sources.add(sourceId);
-				notifyListeners(KonsumerEvent.STOPPED);
+				listener.opened();
 			} else if (sources.contains(sourceId)) {
 				log.info("CircuitBreaker has already been opened by {}", sourceId);
 			} else {
@@ -84,50 +76,11 @@ public class SimpleCircuitBreaker implements CircuitBreaker {
 			if (sources.size() == 1 && sources.contains(sourceId)) {
 				open = false;
 				sources.remove(sourceId);
-				notifyListeners(KonsumerEvent.RESUMED);
+				listener.closed();
 				log.info("conditionalClose - Closing - {}", Thread.currentThread().getName());
 				mutex.notifyAll();
 			} else {
 				sources.remove(sourceId);
-			}
-		}
-	}
-
-	@Override
-	public void addListener(KonsumerEventListener listener) {
-		listeners.add(listener);
-	}
-
-	/**
-	 * The listener will call the listener in a separate trade to avoid running the callbacks while holding the lock
-	 * on the circuit breaker.
-	 */
-	private void notifyListeners(final KonsumerEvent event) {
-		for(final KonsumerEventListener listener : listeners) {
-			try {
-				callbackExecutor.submit(new CircuitBreakerEventCallbackTask(listener, event));
-			} catch (RejectedExecutionException e) {
-				log.warn("Submission of task to executor was rejected", e);
-			}
-		}
-	}
-
-	private static class CircuitBreakerEventCallbackTask implements Runnable {
-
-		private final KonsumerEventListener listener;
-		private final KonsumerEvent event;
-
-		public CircuitBreakerEventCallbackTask(KonsumerEventListener listener, KonsumerEvent event) {
-			this.listener = listener;
-			this.event = event;
-		}
-
-		@Override
-		public void run() {
-			try {
-				listener.eventNotification(event);
-			} catch (Exception e) {
-				log.warn("Exception when notifying listeners of circuit breaker event", e);
 			}
 		}
 	}

--- a/src/main/java/smartthings/konsumer/event/KonsumerEvent.java
+++ b/src/main/java/smartthings/konsumer/event/KonsumerEvent.java
@@ -1,5 +1,5 @@
 package smartthings.konsumer.event;
 
 public enum KonsumerEvent {
-	RESUMED, STOPPED
+	STARTED, SUSPENDED, RESUMED, STOPPED
 }

--- a/src/main/java/smartthings/konsumer/filterchain/MessageFilter.java
+++ b/src/main/java/smartthings/konsumer/filterchain/MessageFilter.java
@@ -4,6 +4,14 @@ import kafka.message.MessageAndMetadata;
 
 public interface MessageFilter {
 
+	void init();
+
+	void suspended();
+
+	void resumed();
+
+	void destroy();
+
 	void handleMessage(MessageAndMetadata<byte[], byte[]> messageAndMetadata, MessageContext ctx) throws Exception;
 
 }

--- a/src/main/java/smartthings/konsumer/filters/BaseMessageFilter.java
+++ b/src/main/java/smartthings/konsumer/filters/BaseMessageFilter.java
@@ -1,0 +1,23 @@
+package smartthings.konsumer.filters;
+
+import kafka.message.MessageAndMetadata;
+import smartthings.konsumer.filterchain.MessageContext;
+import smartthings.konsumer.filterchain.MessageFilter;
+
+public abstract class BaseMessageFilter implements MessageFilter {
+
+	@Override
+	public void init() {}
+
+	@Override
+	public void suspended() {}
+
+	@Override
+	public void resumed() {}
+
+	@Override
+	public void destroy() {}
+
+	@Override
+	public abstract void handleMessage(MessageAndMetadata<byte[], byte[]> message, MessageContext ctx) throws Exception;
+}

--- a/src/main/java/smartthings/konsumer/filters/RetryMessageFilter.java
+++ b/src/main/java/smartthings/konsumer/filters/RetryMessageFilter.java
@@ -9,7 +9,7 @@ import smartthings.konsumer.filterchain.MessageFilter;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
-public class RetryMessageFilter implements MessageFilter {
+public class RetryMessageFilter extends BaseMessageFilter {
 
 	private final static Logger log = LoggerFactory.getLogger(RetryMessageFilter.class);
 

--- a/src/main/java/smartthings/konsumer/stream/SingleMessageConsumer.java
+++ b/src/main/java/smartthings/konsumer/stream/SingleMessageConsumer.java
@@ -36,7 +36,7 @@ public class SingleMessageConsumer implements Runnable {
 
 	private void processMessage(MessageAndMetadata<byte[], byte[]> messageAndMetadata) {
 		try {
-			filterChain.handle(messageAndMetadata);
+			filterChain.handle(messageAndMetadata, circuitBreaker);
 			return;
 		} catch (Exception e) {
 			log.error("Exception occurred during message processing", e);

--- a/src/main/java/smartthings/konsumer/stream/ThreadedMessageConsumer.java
+++ b/src/main/java/smartthings/konsumer/stream/ThreadedMessageConsumer.java
@@ -70,7 +70,7 @@ public class ThreadedMessageConsumer implements Runnable {
 				@Override
 				public void run() {
 					try {
-						filterChain.handle(messageAndMetadata);
+						filterChain.handle(messageAndMetadata, circuitBreaker);
 					} catch (Exception e) {
 						handleException(messageAndMetadata, e);
 					} finally {
@@ -101,6 +101,6 @@ public class ThreadedMessageConsumer implements Runnable {
 	}
 
 	public void handleException(MessageAndMetadata<byte[], byte[]> messageAndMetadata, Throwable t) {
-		log.warn("Exception when processing message", t);
+		//log.warn("Exception when processing message", t);
 	}
 }

--- a/src/test/groovy/smartthings/konsumer/stream/SingleMessageConsumerSpec.groovy
+++ b/src/test/groovy/smartthings/konsumer/stream/SingleMessageConsumerSpec.groovy
@@ -29,7 +29,7 @@ class SingleMessageConsumerSpec extends Specification {
 		2 * streamIterator.hasNext() >> { cnt += 1; return cnt == 1 }
 		1 * circuitBreaker.blockIfOpen()
 		1 * streamIterator.next() >> messageAndMetadata
-		1 * filterChain.handle(messageAndMetadata)
+		1 * filterChain.handle(messageAndMetadata, circuitBreaker)
 		0 * _
 	}
 
@@ -47,7 +47,7 @@ class SingleMessageConsumerSpec extends Specification {
 		(numMessages + 1) * streamIterator.hasNext() >> { cnt += 1; return cnt <= numMessages }
 		numMessages * circuitBreaker.blockIfOpen()
 		numMessages * streamIterator.next() >> messageAndMetadata
-		numMessages * filterChain.handle(messageAndMetadata)
+		numMessages * filterChain.handle(messageAndMetadata, circuitBreaker)
 		0 * _
 	}
 }

--- a/src/test/groovy/smartthings/konsumer/stream/ThreadedMessageConsumerSpec.groovy
+++ b/src/test/groovy/smartthings/konsumer/stream/ThreadedMessageConsumerSpec.groovy
@@ -41,7 +41,7 @@ class ThreadedMessageConsumerSpec extends Specification {
 		2 * streamIterator.hasNext() >> { cnt += 1; return cnt == 1 }
 		1 * circuitBreaker.blockIfOpen()
 		1 * streamIterator.next() >> messageAndMetadata
-		1 * filterChain.handle(messageAndMetadata)
+		1 * filterChain.handle(messageAndMetadata, circuitBreaker)
 		0 * _
 	}
 
@@ -61,7 +61,7 @@ class ThreadedMessageConsumerSpec extends Specification {
 		(numMessages + 1) * streamIterator.hasNext() >> { cnt += 1; return cnt <= numMessages }
 		numMessages * circuitBreaker.blockIfOpen()
 		numMessages * streamIterator.next() >> messageAndMetadata
-		numMessages * filterChain.handle(messageAndMetadata)
+		numMessages * filterChain.handle(messageAndMetadata, circuitBreaker)
 		0 * _
 	}
 

--- a/src/test/java/smartthings/konsumer/example/LoggingMessageProcessor.java
+++ b/src/test/java/smartthings/konsumer/example/LoggingMessageProcessor.java
@@ -13,10 +13,12 @@ public class LoggingMessageProcessor implements MessageProcessor {
 	@Override
 	public void processMessage(MessageAndMetadata<byte[], byte[]> bytes) throws Exception {
 		String content = new String(bytes.message(), StandardCharsets.UTF_8);
-		if ("FAIL".equals(content)) {
+		if (content.startsWith("FAIL")) {
+			log.warn("Thread {} - Failed message - {}",
+				Thread.currentThread().getName(), content);
 			throw new RuntimeException("Failed to process message");
 		} else {
-			log.warn("Thread {} - Got message - {}",
+			log.info("Thread {} - Got message - {}",
 				Thread.currentThread().getName(), content);
 		}
 	}

--- a/src/test/java/smartthings/konsumer/example/Main.groovy
+++ b/src/test/java/smartthings/konsumer/example/Main.groovy
@@ -4,6 +4,8 @@ import smartthings.konsumer.KafkaListener
 import smartthings.konsumer.ListenerConfig
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import smartthings.konsumer.event.KonsumerEvent
+import smartthings.konsumer.event.KonsumerEventListener
 import smartthings.konsumer.filters.RetryMessageFilter
 
 public class Main {
@@ -17,13 +19,20 @@ public class Main {
 				.processingThreads(8)
 				.processingQueueSize(10)
 				.consumerGroup("konsumer-test")
-				.topic("logs")
+				.topic("konsumer_test")
 				.zookeeper("127.0.0.1:2181")
 				.setProperty("auto.offset.reset", "smallest")
 				.build();
 		final KafkaListener consumer = new KafkaListener(config);
 		// call the blocking run method so the application doesn't exit and
 		// stop the queue processing
+
+		consumer.registerEventListener(new KonsumerEventListener() {
+			@Override
+			void eventNotification(KonsumerEvent event) {
+				log.info('KonsumerEvent: {}', event.name())
+			}
+		})
 
 		consumer.runAndBlock(new LoggingMessageProcessor(),
 				new RetryMessageFilter(3)


### PR DESCRIPTION
Lifecycle events on the filters are useful for things like resetting counters on filters after the circuit breaker has been opened. This change also provides the same event callbacks on the kafkaListener.

@charliek
